### PR TITLE
Add drag-to-move feature

### DIFF
--- a/src-tauri/src/commands/file_command.rs
+++ b/src-tauri/src/commands/file_command.rs
@@ -111,15 +111,19 @@ pub fn move_file_or_folder(src: &str, dst: &str) -> Result<(), InvokeError> {
     let sftp: Sftp = get_sftp_session().map_err(|e| InvokeError::from(e.to_string()))?;
     let hugo_config = get_hugo_config().map_err(|e| InvokeError::from(e.to_string()))?;
 
+    // Sanitize paths to avoid accidental absolute paths or duplicate separators
+    let sanitized_src = src.trim_start_matches('/');
+    let sanitized_dst = dst.trim_start_matches('/');
+
     move_file(
         &sftp,
         &Path::new(&format!(
             "{}/content/{}/{}",
-            &hugo_config.base_path, &hugo_config.content_path, src
+            &hugo_config.base_path, &hugo_config.content_path, sanitized_src
         )),
         &Path::new(&format!(
             "{}/content/{}/{}",
-            &hugo_config.base_path, &hugo_config.content_path, dst
+            &hugo_config.base_path, &hugo_config.content_path, sanitized_dst
         )),
     )
     .map_err(|e| InvokeError::from(e.to_string()))?;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,8 @@ import "./app.css"
 import App from "./App.svelte";
 
 const app = new App({
-  target: document.getElementById("app"),
+  // The app element is present in index.html, so assertion is safe
+  target: document.getElementById("app")!,
 });
 
 export default app;

--- a/src/sidebar/TreeNode.svelte
+++ b/src/sidebar/TreeNode.svelte
@@ -221,9 +221,6 @@
     <div
         class="flex items-center"
         class:drag-over={dragOver}
-        draggable="true"
-        on:dragstart={handleDragStart}
-        on:dragend={handleDragEnd}
         on:dragover={handleDragOver}
         on:dragenter={handleDragEnter}
         on:dragleave={handleDragLeave}
@@ -239,6 +236,9 @@
                     // onFileClick(event, `${path}${node.name}`);
                 }}
                 class="cursor-pointer w-6 h-6 rounded"
+                draggable="true"
+                on:dragstart={handleDragStart}
+                on:dragend={handleDragEnd}
             >
             {#if $isExpanded}
                 <FolderOpen />
@@ -266,6 +266,9 @@
                     ? 'bg-selected-file'
                     : ''}"
                 on:click={onFileClick}
+                draggable="true"
+                on:dragstart={handleDragStart}
+                on:dragend={handleDragEnd}
             >
                 {node.name}
             </button>

--- a/src/sidebar/TreeNode.svelte
+++ b/src/sidebar/TreeNode.svelte
@@ -144,9 +144,12 @@
 
     function handleDragStart(event: DragEvent) {
         event.dataTransfer?.setData("text/plain", filePath);
+        // Indicate we support moving the item
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.dropEffect = "move";
+        }
         draggingFilePath.set(filePath);
-        const target = event.currentTarget as HTMLElement;
-        event.dataTransfer?.setDragImage(target, 0, 0);
     }
 
     function handleDragEnd() {
@@ -158,6 +161,9 @@
             event.preventDefault();
             isExpanded.set(true);
             dragOver = true;
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = "move";
+            }
         }
     }
 
@@ -170,6 +176,9 @@
     function handleDragOver(event: DragEvent) {
         if (node.type_ === "Directory") {
             event.preventDefault();
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = "move";
+            }
         }
     }
 
@@ -177,6 +186,9 @@
         if (node.type_ !== "Directory") return;
         event.preventDefault();
         dragOver = false;
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = "move";
+        }
         const src = event.dataTransfer?.getData("text/plain") || $draggingFilePath;
         if (!src || src === filePath) return;
         const name = src.split("/").pop();
@@ -225,6 +237,9 @@
         on:dragenter={handleDragEnter}
         on:dragleave={handleDragLeave}
         on:drop={handleDrop}
+        on:dragstart={handleDragStart}
+        on:dragend={handleDragEnd}
+        draggable="true"
         role="treeitem"
         aria-selected={$selectedCursor === filePath}
         tabindex="0"
@@ -236,9 +251,6 @@
                     // onFileClick(event, `${path}${node.name}`);
                 }}
                 class="cursor-pointer w-6 h-6 rounded"
-                draggable="true"
-                on:dragstart={handleDragStart}
-                on:dragend={handleDragEnd}
             >
             {#if $isExpanded}
                 <FolderOpen />
@@ -266,9 +278,6 @@
                     ? 'bg-selected-file'
                     : ''}"
                 on:click={onFileClick}
-                draggable="true"
-                on:dragstart={handleDragStart}
-                on:dragend={handleDragEnd}
             >
                 {node.name}
             </button>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,3 +4,4 @@ export const selectedFilePath = writable<string>("");
 export const selectedCursor = writable<string>("");
 export const isConnected = writable(false);
 export const url = writable<string>("");
+export const draggingFilePath = writable<string>("");


### PR DESCRIPTION
## Summary
- enable drag & drop on file tree nodes
- ensure TypeScript knows the mount point is not null
- sanitize paths for tauri move command
- highlight target folders on drag and expand them automatically

## Testing
- `npm run check` *(fails: svelte-check not found)*
- `cargo check` *(fails: `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8f26c3c0832595380277e87fdc9b