### PR TITLE
Enable drag-and-drop in sidebar

### DIFF
--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,3 +4,4 @@ export const selectedFilePath = writable<string>("");
 export const selectedCursor = writable<string>("");
 export const isConnected = writable(false);
 export const url = writable<string>("");
+export const draggingPath = writable<string | null>(null);


### PR DESCRIPTION
## Summary
- track dragging file path in stores
- implement drag start/over/drop handlers in `TreeNode`
- highlight drop targets while dragging

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686ffafee79483259baeba4e13150793