### PR TITLE
Fix drag-and-drop while renaming

### DIFF
--- a/src/stores.ts
+++ b/src/stores.ts
@@ -5,3 +5,5 @@ export const selectedCursor = writable<string>("");
 export const isConnected = writable(false);
 export const url = writable<string>("");
 export const draggingPath = writable<string | null>(null);
+// Indicates whether any filename is currently being edited.
+export const isEditingFileName = writable(false);


### PR DESCRIPTION
## Summary
- store global state when a filename is being edited
- block drag and drop if a rename is active

## Testing
- `npm run check`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68700b82145c83259d38bba626650272