### PR TITLE
Fix terminal cd path and url update

### DIFF
--- a/src/sidebar/SettingsPopup.svelte
+++ b/src/sidebar/SettingsPopup.svelte
@@ -3,6 +3,7 @@
   import DynamicField from "../component/DynamicField.svelte";
   import { createDefaultAppConfig, type AppConfig } from "../types/setting";
   import Popup from "../component/Popup.svelte";
+  import { url, contentPath } from "../stores";
 
   export let show: boolean;
   export let closeSettings: () => void;
@@ -24,6 +25,8 @@
         ...createDefaultAppConfig(),
         ...loadedConfig,
       };
+      url.set(config.cms_config.hugo_config.url);
+      contentPath.set(config.cms_config.hugo_config.content_path);
     } catch (error) {
       console.log("Failed to load config:", error);
       config = createDefaultAppConfig();
@@ -36,6 +39,8 @@
     try {
       await invoke("save_config", { config });
       await invoke("update_and_connect", { config });
+      url.set(config.cms_config.hugo_config.url);
+      contentPath.set(config.cms_config.hugo_config.content_path);
     } catch (error) {
       console.error(error);
     } finally {

--- a/src/sidebar/TerminalPopup.svelte
+++ b/src/sidebar/TerminalPopup.svelte
@@ -1,26 +1,43 @@
 <script lang="ts">
   import Popup from "../component/Popup.svelte";
   import { invoke } from "@tauri-apps/api/core";
-  import { afterUpdate } from "svelte";
+  import { afterUpdate, onMount } from "svelte";
   export let show: boolean;
   export let closeTerminal: () => void;
 
   let command = "";
   let output = "";
+  let currentDir = "";
   let terminalEl: HTMLPreElement | null = null;
+
+  onMount(async () => {
+    try {
+      const res: string = await invoke("execute_ssh", { cmd: "pwd" });
+      currentDir = res.trim();
+    } catch (e) {
+      console.error(e);
+    }
+  });
 
   async function sendCommand() {
     const cmd = command.trim();
     if (!cmd) return;
     if (cmd === "clear") {
       output = "";
-    } else {
-      try {
-        const result: string = await invoke("execute_ssh", { cmd });
-        output += `$ ${cmd}\n${result}\n`;
-      } catch (e) {
-        output += `$ ${cmd}\nError: ${e}\n`;
-      }
+      command = "";
+      return;
+    }
+    try {
+      const result: string = await invoke("execute_ssh", {
+        cmd: `cd ${currentDir}; ${cmd}; pwd`,
+      });
+      const lines = result.trim().split(/\r?\n/);
+      const newDir = lines.pop();
+      if (newDir) currentDir = newDir.trim();
+      const cmdOutput = lines.join("\n");
+      output += `$ ${cmd}\n${cmdOutput}\n`;
+    } catch (e) {
+      output += `$ ${cmd}\nError: ${e}\n`;
     }
     command = "";
   }
@@ -35,11 +52,17 @@
   <Popup {show} closePopup={closeTerminal}>
     <h2 class="font-bold text-lg mb-2">SSH Terminal</h2>
     <pre class="terminal-output" bind:this={terminalEl}>{output}</pre>
-    <div class="flex mt-2 space-x-2">
+    <div class="flex mt-2 space-x-2 items-center">
+      <span class="text-gray-400">{currentDir}</span>
       <input
         class="flex-grow p-2 rounded bg-gray-800 text-white"
         bind:value={command}
-        on:keydown={(e) => e.key === 'Enter' && sendCommand()}
+        on:keydown={(e) => {
+          if (e.key === 'Enter') {
+            e.stopPropagation();
+            sendCommand();
+          }
+        }}
         placeholder="Enter command" />
       <button class="bg-blue-600 hover:bg-blue-800 px-4 rounded" on:click={sendCommand}>Run</button>
     </div>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -4,6 +4,7 @@ export const selectedFilePath = writable<string>("");
 export const selectedCursor = writable<string>("");
 export const isConnected = writable(false);
 export const url = writable<string>("");
+export const contentPath = writable<string>("");
 export const draggingPath = writable<string | null>(null);
 // Indicates whether any filename is currently being edited.
 export const isEditingFileName = writable(false);

--- a/src/topbar/TopBar.svelte
+++ b/src/topbar/TopBar.svelte
@@ -3,30 +3,29 @@
   export let toggleMenu: () => void;
   import MdArrowForward from "svelte-icons/md/MdArrowForward.svelte";
   import DiIe from 'svelte-icons/di/DiIe.svelte'
-  import { selectedFilePath } from "../stores";
+  import { selectedFilePath, url, contentPath } from "../stores";
   import { invoke } from "@tauri-apps/api/core";
   import { open } from "@tauri-apps/plugin-shell";
   import { onMount } from "svelte";
-  import { type AppConfig } from "../types/setting";
+  import type { AppConfig } from "../types/setting";
 
   function handleOpenPage() {
     let cleanedPath = $selectedFilePath
       .replace(/\.md$/, "")
       .replace(/\/_index$/, "")
       .toLowerCase();
-      
-    const fullUrl = new URL(`${contentPath}${cleanedPath}`, url);
+
+    const fullUrl = new URL(`${$contentPath}${cleanedPath}`, $url);
     open(fullUrl.toString().toLowerCase());
   }
 
   let config: AppConfig;
-  let url: string = "https://www.naver.com";
-  let contentPath: string = "/content/";
+
   onMount(async () => {
     try {
       config = await invoke("get_config");
-      url = config.cms_config.hugo_config.url;
-      contentPath = config.cms_config.hugo_config.content_path;
+      url.set(config.cms_config.hugo_config.url);
+      contentPath.set(config.cms_config.hugo_config.content_path);
     } catch (error) {
       console.error("Failed to get config:", error);
     }


### PR DESCRIPTION
## Summary
- show and maintain current path in terminal popup
- prevent rename when hitting Enter in terminal
- update URL and content path when saving settings
- expose URL and content path stores for top bar

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68707668d3208325953fd41c0f510134